### PR TITLE
Added the ability to customize error handler in simplehttp. 

### DIFF
--- a/ecosystem/http/handler.go
+++ b/ecosystem/http/handler.go
@@ -4,6 +4,16 @@ import (
 	"net/http"
 )
 
+// ErrorHandler is an error handling function for HTTP handlers
+type ErrorHandler func(http.ResponseWriter, *http.Request, error)
+
+// DefaultErrorHandler is the default error handling function for HTTP handlers, it
+// Sets the response status based on the handler's returned error using the SimpleError to HTTP mapping.
+// The DefaultErrorHandler can be changed to also provide other error handling such as logging.
+var DefaultErrorHandler ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+	SetStatus(w, err)
+}
+
 // Handler is analogous to http.Handler but returns an error
 type Handler interface {
 	ServeHTTP(http.ResponseWriter, *http.Request) error
@@ -11,31 +21,40 @@ type Handler interface {
 
 // HandlerAdapter adapts the Handler interface to the http.Handler interface
 type HandlerAdapter struct {
-	h Handler
+	h          Handler
+	errHandler ErrorHandler
 }
 
-func NewHandlerAdapter(h Handler) *HandlerAdapter {
-	return &HandlerAdapter{h: h}
+// NewHandlerAdapter returns a HandlerAdapter that can be used with the standard library http package.
+func NewHandlerAdapter(h Handler, opts ...HandlerOption) *HandlerAdapter {
+	ha := &HandlerAdapter{h: h, errHandler: DefaultErrorHandler}
+	for _, opt := range opts {
+		opt(ha)
+	}
+	return ha
 }
 
 // ServeHTTP calls the underlying handler's ServeHTTP method and calls SetStatus on the returned error
 func (h HandlerAdapter) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	err := h.h.ServeHTTP(writer, request)
-	SetStatus(writer, err)
+	h.errHandler(writer, request, err)
 }
 
 // HandlerFunc is analogous to http.HandlerFunc but returns an error
 type HandlerFunc func(http.ResponseWriter, *http.Request) error
 
+// ServerHTTP implements the Handler interface
+func (h HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+	return h(w, r)
+}
+
 // Adapter returns a http.HandlerFunc which calls SetStatus on the returned error
-func (h HandlerFunc) Adapter() http.HandlerFunc {
-	return NewHandlerFuncAdapter(h)
+func (h HandlerFunc) Adapter(opts ...HandlerOption) http.HandlerFunc {
+	return NewHandlerFuncAdapter(h, opts...)
 }
 
 // NewHandlerFuncAdapter returns a http.HandlerFunc which calls SetStatus on the returned error
-func NewHandlerFuncAdapter(h HandlerFunc) http.HandlerFunc {
-	return func(writer http.ResponseWriter, request *http.Request) {
-		err := h(writer, request)
-		SetStatus(writer, err)
-	}
+func NewHandlerFuncAdapter(h HandlerFunc, opts ...HandlerOption) http.HandlerFunc {
+	ha := NewHandlerAdapter(h, opts...)
+	return ha.ServeHTTP
 }

--- a/ecosystem/http/options.go
+++ b/ecosystem/http/options.go
@@ -1,0 +1,11 @@
+package simplehttp
+
+// HandlerOption are options to change the behaviour of the HandlerAdapter
+type HandlerOption func(adapter *HandlerAdapter)
+
+// WithErrorHandler is an HandlerOption to change the error handling function
+func WithErrorHandler(h ErrorHandler) HandlerOption {
+	return func(a *HandlerAdapter) {
+		a.errHandler = h
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/lobocv/simplerr
 
 go 1.17
 
-require github.com/stretchr/testify v1.7.0
+require (
+	github.com/stretchr/testify v1.7.0
+	google.golang.org/grpc v1.44.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
@@ -12,7 +15,6 @@ require (
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
 	golang.org/x/text v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/grpc v1.44.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -82,6 +83,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
This can be usedful for adding an error logging middleware:

- Users can override the DefaultErrorHandler
- Users can use a HandlerOption to change the error handling for a specific Handler