### PR TITLE
Sentry stack trace integration

### DIFF
--- a/call_stack.go
+++ b/call_stack.go
@@ -1,6 +1,9 @@
 package simplerr
 
-import "runtime"
+import (
+	"runtime"
+	"strings"
+)
 
 const (
 	// maxStackFrames are the maximum number of stack frames returned with the error when using WithStackTrace
@@ -9,16 +12,17 @@ const (
 
 // Call contains information for a specific call in the call stack
 type Call struct {
-	Line int
-	File string
-	Func string
+	Line     int
+	File     string
+	Func     string
+	FuncName string
+	Package  string
 }
 
-// stackTrace returns the call stack trace with `skip` frames skipped
-func stackTrace(skip int) []Call {
+// stackTrace returns a more human readable form of the the stack trace from the slice of program counters
+func stackTrace(pcs []uintptr) []Call {
 	calls := make([]Call, 0, maxStackFrames)
-	pcs := make([]uintptr, maxStackFrames)
-	runtime.Callers(skip, pcs)
+
 	frames := runtime.CallersFrames(pcs)
 	for {
 		f, ok := frames.Next()
@@ -26,12 +30,57 @@ func stackTrace(skip int) []Call {
 			break
 		}
 
+		var pkg string
+		function := f.Function
+
+		if function != "" {
+			pkg, function = splitQualifiedFunctionName(function)
+		}
+
 		calls = append(calls, Call{
-			Line: f.Line,
-			File: f.File,
-			Func: runtime.FuncForPC(f.PC).Name(),
+			Line:     f.Line,
+			File:     f.File,
+			FuncName: function,
+			Package:  pkg,
+			Func:     runtime.FuncForPC(f.PC).Name(),
 		})
 
 	}
 	return calls
+}
+
+// rawStackFrames extracts the slice of program counters associated with the stack trace and skips the first `skip`
+// number of calls.
+func rawStackFrames(skip int) []uintptr {
+	pcs := make([]uintptr, maxStackFrames)
+	runtime.Callers(skip, pcs)
+	return pcs
+}
+
+// packageName returns the name of the package from the fully qualified package name
+func packageName(fullName string) string {
+	var pkg string
+
+	// Look at the last segment only
+	pathend := strings.LastIndex(fullName, "/")
+	if pathend < 0 {
+		pathend = 0
+	}
+
+	// Look for the "." that separates the package name from the function name
+	// and take only the first part
+	i := strings.Index(fullName[pathend:], ".")
+	if i != -1 {
+		pkg = fullName[:pathend+i]
+	}
+	return pkg
+}
+
+// splitQualifiedFunctionName splits a package path-qualified function name into
+// package name and function name. Such qualified names are found in
+// runtime.Frame.Function values.
+func splitQualifiedFunctionName(name string) (pkg string, fun string) {
+	pkg = packageName(name)
+	fun = strings.TrimPrefix(name, pkg+".")
+	return
 }

--- a/errors.go
+++ b/errors.go
@@ -31,12 +31,13 @@ type SimpleError struct {
 	// attr is a list of custom attributes attached the error
 	attr []attribute
 	// stackTrace is the call stack trace for the error
-	stackTrace []Call
+	rawStackFrames []uintptr
 }
 
 // New creates a new SimpleError from a formatted string
 func New(_fmt string, args ...interface{}) *SimpleError {
-	return &SimpleError{msg: fmt.Sprintf(_fmt, args...), code: CodeUnknown, stackTrace: stackTrace(3)}
+	rawFrames := rawStackFrames(3)
+	return &SimpleError{msg: fmt.Sprintf(_fmt, args...), code: CodeUnknown, rawStackFrames: rawFrames}
 }
 
 // Error satisfies the `error` interface. It uses the `simplerr.Formatter` to generate an error string.
@@ -172,7 +173,13 @@ func (e *SimpleError) GetDescription() string {
 
 // StackTrace returns the stack trace at the point at which the error was raised.
 func (e *SimpleError) StackTrace() []Call {
-	return e.stackTrace
+	return stackTrace(e.rawStackFrames)
+}
+
+// StackFrames returns a slice of pointers to program counters
+// This method is primarily used to better integrate with sentry stack trace extraction
+func (e *SimpleError) StackFrames() []uintptr {
+	return e.rawStackFrames
 }
 
 // Unwrap implement the interface required for error unwrapping. It returns the underlying (wrapped) error.

--- a/errors_test.go
+++ b/errors_test.go
@@ -3,9 +3,10 @@ package simplerr
 import (
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/suite"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type CustomError struct {
@@ -22,6 +23,8 @@ type TestSuite struct {
 
 func (s *TestSuite) checkCall(c Call, funcName string) {
 	s.True(strings.HasSuffix(c.Func, funcName))
+	s.Equal(c.FuncName, funcName)
+	s.Equal(c.Package, "github.com/lobocv/simplerr")
 }
 
 func TestErrors(t *testing.T) {
@@ -499,6 +502,10 @@ func (s *TestSuite) TestStackTrace() {
 	s.checkCall(stack[1], "Third")
 	s.checkCall(stack[2], "Second")
 	s.checkCall(stack[3], "First")
+
+	// There's not really a great way to test the raw pointers. As long as this isn't an empty
+	// list, we should be fine because StackTrace() is already tested, and it uses StackFrames()
+	s.NotEmpty(e.StackFrames())
 }
 
 func Fourth() *SimpleError {

--- a/util.go
+++ b/util.go
@@ -7,14 +7,14 @@ import (
 
 // Wrap wraps the error in a SimpleError. It defaults the error code to CodeUnknown.
 func Wrap(err error) *SimpleError {
-	return &SimpleError{parent: err, stackTrace: stackTrace(3)}
+	return &SimpleError{parent: err, rawStackFrames: rawStackFrames(3)}
 }
 
 // Wrapf returns a new SimpleError by wrapping an error with a formatted message string.
 // It defaults the error code to CodeUnknown
 func Wrapf(err error, msg string, a ...interface{}) *SimpleError {
 	msg = fmt.Sprintf(msg, a...)
-	return &SimpleError{parent: err, msg: msg, stackTrace: stackTrace(3)}
+	return &SimpleError{parent: err, msg: msg, rawStackFrames: rawStackFrames(3)}
 }
 
 // As attempts to find a SimpleError in the chain of errors, similar to errors.As().


### PR DESCRIPTION
Added StackFrames() []uintptr method to SimpleError so that it integrates with stack trace extraction in sentry

- Added FuncName and Package to the stack trace Call{}